### PR TITLE
Sl-13687 base64 attachment processing

### DIFF
--- a/lib/ews/message_accessors.rb
+++ b/lib/ews/message_accessors.rb
@@ -45,8 +45,8 @@ module Viewpoint::EWS::MessageAccessors
     yield msg if block_given?
     if msg.has_attachments?
       draft = msg.draft
-      msg.draft = true
       resp = parse_create_item(ews.create_item(msg.to_ews))
+      msg.draft = true
       msg.file_attachments.each do |f|
         next unless f.kind_of?(File) or f.kind_of?(Tempfile)
         resp.add_file_attachment(f)

--- a/lib/ews/message_accessors.rb
+++ b/lib/ews/message_accessors.rb
@@ -47,13 +47,23 @@ module Viewpoint::EWS::MessageAccessors
       draft = msg.draft
       resp = parse_create_item(ews.create_item(msg.to_ews))
       msg.draft = true
-      msg.file_attachments.each do |f|
-        next unless f.kind_of?(File) or f.kind_of?(Tempfile)
-        resp.add_file_attachment(f)
+      msg.file_attachments.each do |attachment|
+        if attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
+          resp.file_attachment_from_file(attachment)
+        elsif attachment.kind_of?(Hash)
+          resp.file_attachment_from_hash(attachment)
+        else
+          next
+        end
       end
-      msg.inline_attachments.each do |f|
-        next unless f.kind_of?(File) or f.kind_of?(Tempfile)
-        resp.add_inline_attachment(f)
+      msg.inline_attachments.each do |attachment|
+        if attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
+          resp.inline_attachment_from_file(attachment)
+        elsif attachment.kind_of?(Hash)
+          resp.inline_attachment_from_hash(attachment)
+        else
+          next
+        end
       end
       if draft
         resp.submit_attachments!

--- a/lib/ews/message_accessors.rb
+++ b/lib/ews/message_accessors.rb
@@ -48,19 +48,19 @@ module Viewpoint::EWS::MessageAccessors
       resp = parse_create_item(ews.create_item(msg.to_ews))
       msg.draft = true
       msg.file_attachments.each do |attachment|
-        if attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
-          resp.file_attachment_from_file(attachment)
-        elsif attachment.kind_of?(Hash)
+        if attachment.kind_of?(Hash)
           resp.file_attachment_from_hash(attachment)
+        elsif attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
+          resp.file_attachment_from_file(attachment)
         else
           next
         end
       end
       msg.inline_attachments.each do |attachment|
-        if attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
-          resp.inline_attachment_from_file(attachment)
-        elsif attachment.kind_of?(Hash)
+        if attachment.kind_of?(Hash)
           resp.inline_attachment_from_hash(attachment)
+        elsif attachment.kind_of?(File) || attachment.kind_of?(Tempfile)
+          resp.inline_attachment_from_file(attachment)
         else
           next
         end

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -27,6 +27,7 @@ module Viewpoint::EWS::SOAP
     include ExchangeUserConfiguration
     include ExchangeSynchronization
     include ExchangeTimeZones
+    include Viewpoint::EWS::Validators::ParamsValidator
 
     attr_accessor :server_version, :auto_deepen, :no_auto_deepen_behavior, :connection, :impersonation_type, :impersonation_address
 
@@ -224,22 +225,6 @@ module Viewpoint::EWS::SOAP
 
     private
     # Private Methods (Builders and Parsers)
-
-    # Validate or set default values for options parameters.
-    # @param [Hash] opts The options parameter passed to an EWS operation
-    # @param [Symbol] key The key in the Hash we are validating
-    # @param [Boolean] required Whether or not this key is required
-    # @param [Object] default_val If the key is not required use this as a
-    #   default value for the operation.
-    def validate_param(opts, key, required, default_val = nil)
-      if required
-        raise EwsBadArgumentError, "Required parameter(#{key}) not passed." unless opts.has_key?(key)
-        opts[key]
-      else
-        raise EwsBadArgumentError, "Default value not supplied." unless default_val
-        opts.has_key?(key) ? opts[key] : default_val
-      end
-    end
 
     # Some operations only exist for certain versions of Exchange Server.
     # This method should be called with the required version and we'll throw

--- a/lib/ews/types/item.rb
+++ b/lib/ews/types/item.rb
@@ -3,6 +3,7 @@ module Viewpoint::EWS::Types
     include Viewpoint::EWS
     include Viewpoint::EWS::Types
     include ItemFieldUriMap
+    include Viewpoint::EWS::Validators::ParamsValidator
 
     def self.included(klass)
       klass.extend ClassMethods
@@ -174,11 +175,12 @@ module Viewpoint::EWS::Types
       end
     end
 
-    def add_file_attachment(file)
-      fa = OpenStruct.new
-      fa.name     = File.basename(file.path)
-      fa.content  = Base64.encode64(file.read)
-      @new_file_attachments << fa
+    def file_attachment_from_file(file)
+      @new_file_attachments << attachment_object_from_file(file)
+    end
+
+    def file_attachment_from_hash(hash)
+      @new_file_attachments << attachment_object_from_hash(hash)
     end
 
     def add_item_attachment(other_item, name = nil)
@@ -188,11 +190,12 @@ module Viewpoint::EWS::Types
       @new_item_attachments << ia
     end
 
-    def add_inline_attachment(file)
-      fi = OpenStruct.new
-      fi.name     = File.basename(file.path)
-      fi.content  = Base64.encode64(file.read)
-      @new_inline_attachments << fi
+    def inline_attachment_from_file(file)
+      @new_inline_attachments << attachment_object_from_file(file)
+    end
+
+    def inline_attachment_from_hash(hash)
+      attachment_object_from_hash(hash)
     end
 
     def submit!
@@ -260,6 +263,20 @@ module Viewpoint::EWS::Types
 
 
     private
+
+    def attachment_object_from_file(file)
+      attachment_object          = OpenStruct.new
+      attachment_object.name     = File.basename(file.path)
+      attachment_object.content  = Base64.encode64(file.read)
+      attachment_object
+    end
+
+    def attachment_object_from_hash(attachment_hash)
+      [:name, :content].each do |key|
+        validate_param(attachment_hash, key, true)
+      end
+      OpenStruct.new(attachment_hash)
+    end
 
     def key_paths
       super.merge(ITEM_KEY_PATHS)

--- a/lib/ews/validators/params_validator.rb
+++ b/lib/ews/validators/params_validator.rb
@@ -1,0 +1,22 @@
+module Viewpoint::EWS::Validators
+  module ParamsValidator
+
+    private
+
+    # Validate or set default values for options parameters.
+    # @param [Hash] opts The options parameter passed to an EWS operation
+    # @param [Symbol] key The key in the Hash we are validating
+    # @param [Boolean] required Whether or not this key is required
+    # @param [Object] default_val If the key is not required use this as a
+    #   default value for the operation.
+    def validate_param(opts, key, required, default_val = nil)
+      if required
+        raise EwsBadArgumentError, "Required parameter(#{key}) not passed." unless opts.has_key?(key)
+        opts[key]
+      else
+        raise EwsBadArgumentError, "Default value not supplied." unless default_val
+        opts.has_key?(key) ? opts[key] : default_val
+      end
+    end
+  end
+end


### PR DESCRIPTION
Base64 encoded attachments now can be handled by `send_message` method.
The main purpose of the introduced changes is to provide base64 encoded attachments from Melody to Cerebro.
Note: EWS `send_message` request requires base64 attachment format.